### PR TITLE
Bugfix command rename missing

### DIFF
--- a/build/commands/Set-TestMetadata.ps1
+++ b/build/commands/Set-TestMetadata.ps1
@@ -217,7 +217,7 @@ function Set-TestMetadata {
 		foreach ($testID in $Test) {
 			#region Preparation
 			try {
-				$metaData = Get-TestMetadata -Test $testID -ErrorAction Stop
+				$metaData = Get-ZtTestMetadata -Test $testID -ErrorAction Stop
 			}
 			catch {
 				$PSCmdlet.WriteError($_)


### PR DESCRIPTION
Renamed the command when moving it to the module internals, failed to update its name in the "Set"-Command